### PR TITLE
downgrade erlang version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 elixir 1.14.2-otp-25
-erlang 25.2.1
+erlang 25.1.2


### PR DESCRIPTION
 Erlang 25.2.1 seems to be causing many people asdf issues, so I'm downgrading back to 25.1.2.