### PR TITLE
Fix wrong formatting keybinding on livebook section

### DIFF
--- a/reading/livebook.livemd
+++ b/reading/livebook.livemd
@@ -203,9 +203,9 @@ Sometimes order of evaluation can cause issues in Exercises by using a stale ver
 
 ## Formatting
 
-You can format Elixir code using the <kbd>ALT</kbd>+<kbd>SHIFT</kbd>+<kbd>F</kbd> (Windows & Linux) Keybinding or <kbd>SHIFT</kbd>+<kbd>OPTION</kbd>+<kbd>F</kbd> (MacOS).
+You can format Elixir code using the <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>I</kbd> (Windows & Linux) Keybinding or <kbd>SHIFT</kbd>+<kbd>OPTION</kbd>+<kbd>I</kbd> (MacOS).
 
-Try uncommenting the following code (Remove the `#` character) then press <kbd>ALT</kbd>+<kbd>SHIFT</kbd>+<kbd>F</kbd> (Windows & Linux) or <kbd>SHIFT</kbd>+<kbd>OPTION</kbd>+<kbd>F</kbd> (MacOS) to format the code.
+Try uncommenting the following code (Remove the `#` character) then press <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>I</kbd> (Windows & Linux) or <kbd>SHIFT</kbd>+<kbd>OPTION</kbd>+<kbd>I</kbd> (MacOS) to format the code.
 
 Notice that the `1 + 1` code moves to the left.
 
@@ -220,7 +220,7 @@ If you have not evaluated any Elixir code cells, you may see a warning.
 Ensure you evaluate any Elixir cell before attempting to use the code format command.
 
 If you cannot format an Elixir cell, you can use this as a clue that you have a syntax error in your code. For example, the following
-code is invalid. Notice that you cannot use <kbd>ALT</kbd>+<kbd>SHIFT</kbd>+<kbd>F</kbd> to format the code.
+code is invalid. Notice that you cannot use <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>I</kbd> to format the code.
 
 ```elixir
           1 +


### PR DESCRIPTION
## What's change

Before: using alt+shift+f for formatting the code doesn't give any effect. the formatting option of livebook (right mouse on cell) make it clear that it should be ctrl+shift+i

After: change the instructed keybinding for formatting to ctrl+shift+i and for mac is instead of using ...+...+f we use ...+...+i