### PR TITLE
fix: correct the way fo calling function expression

### DIFF
--- a/exercises/rock_paper_scissors.livemd
+++ b/exercises/rock_paper_scissors.livemd
@@ -96,8 +96,8 @@ Bind a `player1_choice` and `player2_choice` variable to `:rock`, `:paper`, or `
   end
 
   cond do
-    beats?(player1, player2) -> "Player1"
-    beats?(player2, player1) -> "Player2"
+    beats?.(player1, player2) -> "Player1"
+    beats?.(player2, player1) -> "Player2"
     player1 == player2 -> "Draw"
   end
   ```


### PR DESCRIPTION
## What's change
Correct the way of how we call the function expression (causing error on example code). It should be with dot notation instead of calling it like regular function.
 ```
# Calling function expression in Elixir

hello = fn -> "hello" end
hello.() # we need dot notation when calling the function expression

```