### PR TITLE
Update example solution for Measurements exercise

### DIFF
--- a/exercises/measurements.livemd
+++ b/exercises/measurements.livemd
@@ -44,7 +44,7 @@ defmodule Measurements do
   end
 
   def average(measurements) do
-    Enum.sum(measurements) / Enum.count(measurements)
+    div(Enum.sum(measurements), Enum.count(measurements))
   end
 end
 ```
@@ -54,6 +54,20 @@ Implement the `Measurements` module according to the documented function example
 
 ```elixir
 defmodule Measurements do
+  @doc """
+  Given a list of measurements as integers, determine the increment between each integer.
+
+  ## Examples
+
+    iex> Measurements.increments([100, 150, 120, 130])
+    [50, -30, 10]
+
+    iex> Measurements.increments([10, 20, 10, 40])
+    [10, -10, 30]
+  """
+  def increments(measurements) do
+  end
+  
   @doc """
   Given a list of measurements as integers, determine how many have increased.
   Each positive change since the previous integer in the list should count as an increase.
@@ -70,20 +84,6 @@ defmodule Measurements do
     1
   """
   def increased(measurements) do
-  end
-
-  @doc """
-  Given a list of measurements as integers, determine the increment between each integer.
-
-  ## Examples
-
-    iex> Measurements.increments([100, 150, 120, 130])
-    [50, -30, 10]
-
-    iex> Measurements.increments([10, 20, 10, 40])
-    [10, -10, 30]
-  """
-  def increments(measurements) do
   end
 
   @doc """


### PR DESCRIPTION
The example solution for the `average` function does not currently pass the doctests, because an integer is expected, and the current solution produces a float. Hence I've updated the division to use div/2 rather than simple division.

I've also re-arranged the order of the functions in the module to match the example solution, so `increments` comes before `increased`. I believe this order is also more intuitive when solving the problem (as I discovered for myself).

**Screenshots**

The current example solution for `average`:
![2023-02-22_17-31](https://user-images.githubusercontent.com/34499789/220581995-84dbbcdc-bcc6-4e62-85a1-f9618c5a34f1.png)

The issue with that:
![2023-02-22_17-32](https://user-images.githubusercontent.com/34499789/220582038-45a4e925-c853-444e-be71-104d3e720002.png)

