### PR TITLE
fix difference in variable names

### DIFF
--- a/exercises/anagram.livemd
+++ b/exercises/anagram.livemd
@@ -27,7 +27,7 @@ For example **bored** and **robed** are anagrams.
 
 ```elixir
 defmodule Anagram do
-  def anagram?(string1, string2) do
+  def anagram?(word, possible_anagram) do
     sort_string(word) == sort_string(possible_anagram)
   end
 
@@ -66,7 +66,7 @@ defmodule Anagram do
     iex> Anagram.anagram?("robed", "bored")
     true
   """
-  def anagram?(string1, string2) do
+  def anagram?(word, possible_anagram) do
   end
 
   @doc """


### PR DESCRIPTION
In the example solution, the function `anagram?` parameter names were `string1` and `string2`, but then later in the function the variables were referred to as `word` and `possible_anagram`. I've updated all instances of `string1` and `string2`.