### PR TITLE
Fix missing animals variable

### DIFF
--- a/reading/enum.livemd
+++ b/reading/enum.livemd
@@ -628,7 +628,7 @@ Enum.any?(1..10_000_000, fn integer -> is_bitstring(integer) end)
 Use [Enum.any/2](https://hexdocs.pm/elixir/Enum.html#any/2) to determine if any of the animals in the `animals` list are `:dogs`. You may change the `animals` list to experiment with [Enum.any/2](https://hexdocs.pm/elixir/Enum.html#any/2).
 
 ```elixir
-[:cats, :dogs, :bears, :lions, :penguins]
+animals = [:cats, :dogs, :bears, :lions, :penguins]
 ```
 
 ## Enum.count/1


### PR DESCRIPTION
`animals` variable is mentioned in the explanation, but missing in block code. I think it will be much clearer to write it (because it's already mentioned)