### PR TITLE
Fix missing keyword list in test result

### DIFF
--- a/exercises/filter_values_by_type.livemd
+++ b/exercises/filter_values_by_type.livemd
@@ -124,7 +124,7 @@ defmodule Filter do
   ## Examples
 
     iex> Filter.lists([1, 2, %{}, {}, [], 1.2, 3.2, :atom, [1, 2], [4, 5, 6]])
-    [[1, 2], [4, 5, 6]]
+    [[], [1, 2], [4, 5, 6]]
   """
   def lists(list) do
   end


### PR DESCRIPTION
The instruction is to
> Filter in lists and keyword lists in list.

So I'm adding the missing empty list which is count as keyword list on test result