### PR TITLE
Filter values fix doctest for lists

### DIFF
--- a/exercises/filter_values_by_type.livemd
+++ b/exercises/filter_values_by_type.livemd
@@ -124,7 +124,7 @@ defmodule Filter do
   ## Examples
 
     iex> Filter.lists([1, 2, %{}, {}, [], 1.2, 3.2, :atom, [1, 2], [4, 5, 6]])
-    [[1, 2], [4, 5, 6]]
+    [[], [1, 2], [4, 5, 6]]
   """
   def lists(list) do
   end

--- a/exercises/measurements.livemd
+++ b/exercises/measurements.livemd
@@ -108,10 +108,10 @@ defmodule Measurements do
   ## Examples
 
     iex> Measurements.average([4, 5, 6])
-    5
+    5.0
 
     iex> Measurements.average([2, 10])
-    6
+    6.0
   """
   def average(measurements) do
   end


### PR DESCRIPTION
Existing doctest did not include an empty list `[ ]` as an expected output, so the doctest was failing.