### PR TITLE
Mix reading change to markdown

### DIFF
--- a/exercises/filter_values_by_type.livemd
+++ b/exercises/filter_values_by_type.livemd
@@ -124,7 +124,7 @@ defmodule Filter do
   ## Examples
 
     iex> Filter.lists([1, 2, %{}, {}, [], 1.2, 3.2, :atom, [1, 2], [4, 5, 6]])
-    [[1, 2], [4, 5, 6]]
+    [[], [1, 2], [4, 5, 6]]
   """
   def lists(list) do
   end

--- a/exercises/measurements.livemd
+++ b/exercises/measurements.livemd
@@ -108,10 +108,10 @@ defmodule Measurements do
   ## Examples
 
     iex> Measurements.average([4, 5, 6])
-    5
+    5.0
 
     iex> Measurements.average([2, 10])
-    6
+    6.0
   """
   def average(measurements) do
   end

--- a/reading/mix.livemd
+++ b/reading/mix.livemd
@@ -271,6 +271,10 @@ end
 
 Then, call the `HelloWorld.Name.random/0` function from the `HelloWorld` module in `hello_world.ex`.
 
+<!-- livebook:{"break_markdown":true} -->
+
+<!-- livebook:{"force_markdown":true} -->
+
 ```elixir
 defmodule HelloWorld do
   def hello do
@@ -278,6 +282,8 @@ defmodule HelloWorld do
   end
 end
 ```
+
+<!-- livebook:{"break_markdown":true} -->
 
 Run your project in the [IEx](https://hexdocs.pm/iex/IEx.html) shell and ensure the `HelloWorld.hello/0` function works as expected.
 


### PR DESCRIPTION
Currently the code cell is outputting an error, because Livebook won't let it re-define the module HelloWorld (it's been defined in a previous cell in). We can leave it as is, the error is just a little confusing. I thought converting it to a markdown cell made the most sense. We can't change the module name, because it's referring to an existing module in the Mix project.

![mix_convert-to-md](https://user-images.githubusercontent.com/34499789/222380538-88b7cf56-1bd4-4541-8b12-1b0a9436bafa.png)
