### PR TITLE
Correct the bulleted list of GitHub key features

### DIFF
--- a/reading/git.livemd
+++ b/reading/git.livemd
@@ -78,7 +78,7 @@ You'll also use GitHub to collaborate on projects with others students, and rece
 
 Since you already have this course running, you likely already have a GitHub Account. If not, you can [Create a GitHub Account](https://docs.github.com/en/get-started/signing-up-for-github/signing-up-for-a-new-github-account). Remember that your GitHub is your public face in the code community. You'll want to ensure you represent yourself well, as it may be seen by future employers and co-workers.
 
-Out of the box, GitHub may ask you to enter your user credentials when running common commands. This can become tedius, and if you experience this, we recommend you [Setup SSH](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) or use an alternative method to avoid tediously r-entering your credentials.
+Out of the box, GitHub may ask you to enter your user credentials when running common commands. This can become tedious, and if you experience this, we recommend you [Setup SSH](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) or use an alternative method to avoid tediously re-entering your credentials.
 
 ## Raising An Issue
 

--- a/reading/git.livemd
+++ b/reading/git.livemd
@@ -53,7 +53,7 @@ GitHub provides several key features for developers, including:
 * **Collaboration**: Developers can easily collaborate on code by "forking" a repository, making changes, and then submitting those changes back to the original repository through a "pull request".
 * **Issues**: Developers can track and manage bugs, feature requests, and other tasks by creating "issues" within a repository.
 * **Pull requests (PRs)**: Developers can submit changes to a repository by creating a "pull request", which can be reviewed and approved by other members of the development team.
-  Branching: Developers can create and work on multiple branches of a repository, allowing them to work on different features or bug fixes without affecting the main codebase.
+* **Branching**: Developers can create and work on multiple branches of a repository, allowing them to work on different features or bug fixes without affecting the main codebase.
 * **Wiki**: Developers can create a wiki for their repository to provide documentation and other information about the codebase.
 
 ## Install Git
@@ -141,7 +141,7 @@ You'll use some common commands for saving changes in Git.
 * `git commit`: Save staged changes into a commit.
 
 We can use `git add` from the command line to stage changes. We can stage a single file
-with `git add <filename>`  or all of the files and folders in the current working directory
+with `git add <filename>` or all of the files and folders in the current working directory
 with `git add .`.
 
 Then we can use `git commit` from the command line to commit all staged changes.


### PR DESCRIPTION
## Issue
A bulleted list in `git.livemd` at line 56 was missing Markdown formatting for the list and text, causing an incongruous render for one item.

### Original render without formatting
The section on `Branching` renders in line with the `Pull Request` section:

<img width="936" alt="image" src="https://user-images.githubusercontent.com/3831217/222990223-9a8974d7-4627-4b34-806d-113384a0294e.png">

### Render with this change
`Branching` is a bullet point and bold like the rest of the list:

<img width="936" alt="image" src="https://user-images.githubusercontent.com/3831217/222990270-8f6add6d-aac4-4afe-8bf3-37005cd4cc82.png">
