### PR TITLE
Fix Regexr and fork links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ F[Forked Repository]
 DY --fork--> F
 ```
 
-You can create a fork by pressing the fork button in the top right corner of the GitHub repository or [click this link to create a fork]([fork](https://github.com/DockYard-Academy/beta_curriculum/fork))
+You can create a fork by pressing the fork button in the top right corner of the GitHub repository or [click this link to create a fork](https://github.com/DockYard-Academy/beta_curriculum/fork)
 
 ## Clone the Repository
 

--- a/reading/regex.livemd
+++ b/reading/regex.livemd
@@ -26,7 +26,7 @@ Upon completing this lesson, a student should be able to answer the following qu
 
 * What are some common use cases for Regular Expressions?
 * How can we use Regular Expressions to manipulate strings?
-* How can we experiment and build Regular Expressions using [Regexr]([Regexr](https://regexr.com/))?
+* How can we experiment and build Regular Expressions using [Regexr](https://regexr.com/)?
 
 ## Overview
 


### PR DESCRIPTION
Hey hey!

The links for Regexr in Regex and the fork link in Contributing are nested/invalid markdown links in the form of:
`[link title]([nested title that breaks the link](http://link.com))`

This PR corrects both of these links with well-formed markdown links!