### PR TITLE
Replace beta_curriculum with curriculum

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ F[Forked Repository]
 DY --fork--> F
 ```
 
-You can create a fork by pressing the fork button in the top right corner of the GitHub repository or [click this link to create a fork]([fork](https://github.com/DockYard-Academy/beta_curriculum/fork))
+You can create a fork by pressing the fork button in the top right corner of the GitHub repository or [click this link to create a fork](https://github.com/DockYard-Academy/beta_curriculum/fork)
 
 ## Clone the Repository
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-DockYard Academy aspires to create a supportive and inclusive environment. We welcome pull requests from everyone and from all experience levels. If you encounter any issues please [Raise An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=) and describe your problem to get help.
+DockYard Academy aspires to create a supportive and inclusive environment. We welcome pull requests from everyone and from all experience levels. If you encounter any issues please [Raise An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=) and describe your problem to get help.
 
 ## Set Up A Code Editor (Recommended)
 
@@ -27,7 +27,7 @@ F[Forked Repository]
 DY --fork--> F
 ```
 
-You can create a fork by pressing the fork button in the top right corner of the GitHub repository or [click this link to create a fork](https://github.com/DockYard-Academy/beta_curriculum/fork)
+You can create a fork by pressing the fork button in the top right corner of the GitHub repository or [click this link to create a fork](https://github.com/DockYard-Academy/curriculum/fork)
 
 ## Clone the Repository
 
@@ -45,7 +45,7 @@ To do this, press the green **CODE** button on your forked repository and copy t
 
 ![GitHub Clone URL](./images//fork_curriculum_clone.png)
 
-Then run the following command in the command line from the folder you want to create your `beta_curriculum` folder in.
+Then run the following command in the command line from the folder you want to create your `curriculum` folder in.
 <div style="background-color: lightcoral; font-weight: bold; padding: 1rem; color: black; margin: 1rem 0;">Ensure you replace URL with the copied URL</div>
 
 ```
@@ -89,13 +89,13 @@ L[Local Repository]
 R --pull changes--> L
 ```
 
-Changes must be pulled to your `main` branch on your local repository, so ensure you are on this branch by running the following from your command line in the `beta_curriculum` folder.
+Changes must be pulled to your `main` branch on your local repository, so ensure you are on this branch by running the following from your command line in the `curriculum` folder.
 
 ```
 git checkout main
 ```
 
-Then run the following command from your command line in the `beta_curriculum` folder to pull the latest changes.
+Then run the following command from your command line in the `curriculum` folder to pull the latest changes.
 
 ```
 git pull
@@ -110,7 +110,7 @@ If you are running the project with Livebook, make sure you completely stop the 
 ## Create A Solutions Branch
 
 If you are interested in completing DockYard Academy content, create a solutions branch.
-To create a new solutions branch, run the following from the `beta_curriculum` folder in your command line. You may replace `2022-10-1` with any branch name.
+To create a new solutions branch, run the following from the `curriculum` folder in your command line. You may replace `2022-10-1` with any branch name.
 
 ```
 git checkout -B 2022-10-1
@@ -142,7 +142,7 @@ git checkout -b feature-branch-name
 
 ## Run Tests
 
-From the `beta_curriculum/utils` folder, run the following command to run all tests.
+From the `curriculum/utils` folder, run the following command to run all tests.
 
 ```
 mix test
@@ -154,7 +154,7 @@ Ensure all tests pass before submitting any Pull Request. Tests should provide y
 
 We have several [Mix Tasks](https://elixirschool.com/en/lessons/intermediate/mix_tasks) which handle automated tasks such as adding navigation, formatting lessons, and spellchecking.
 
-Before submitting any Pull Request, run the following command from the `beta_curriculum/utils` folder.
+Before submitting any Pull Request, run the following command from the `curriculum/utils` folder.
 
 ```
 mix bc
@@ -240,7 +240,7 @@ Ensure that all GitHub Actions Pass after submitting your Pull Request.
 
 We recommend reading through your code changes after submitting your Pull Request.
 
-First, find your Pull Request in the [DockYard Academy Pull Requests](https://github.com/DockYard-Academy/beta_curriculum/pulls) tab. Then click on the **Files Changed** tab to view your changed files. Ensure there are no issues and that you are happy with your changes.
+First, find your Pull Request in the [DockYard Academy Pull Requests](https://github.com/DockYard-Academy/curriculum/pulls) tab. Then click on the **Files Changed** tab to view your changed files. Ensure there are no issues and that you are happy with your changes.
 
 ## Receive a Pull Request Review
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
 # DockYard Academy
 
 The DockYard Academy curriculum is an open source curriculum to help students learn Elixir.
-The `beta_curriculum` is a work in progress effort available for feedback and contribution.
+The `curriculum` is a work in progress effort available for feedback and contribution.
 When launched, this curriculum will be used as the primary teaching material in [DockYard Academy](https://dockyard.com/blog/2022/07/26/what-to-expect-from-the-dockyard-academy-q-a-with-instructor-brooklin-myers).
 
 Contact Brooklin (brooklin.myers@dockyard.com) or DM at [@BrooklinJMyers](https://twitter.com/BrooklinJMyers) on Twitter if you would like more information.
 
 ## Want To Get Involved?
 
-Contributors and beta testers are welcome to go through the course, raise issues, and make PRs. See the [Contributor Guide](https://github.com/DockYard-Academy/beta_curriculum/blob/main/CONTRIBUTING.md).
+Contributors and beta testers are welcome to go through the course, raise issues, and make PRs. See the [Contributor Guide](https://github.com/DockYard-Academy/curriculum/blob/main/CONTRIBUTING.md).
 
-See our list of [Open Issues](https://github.com/DockYard-Academy/beta_curriculum/issues). You can raise an issue to get support.
+See our list of [Open Issues](https://github.com/DockYard-Academy/curriculum/issues). You can raise an issue to get support.
 
 ## QuickStart
 
-The following QuickStart Guide will let you quickly try the course. For a long-term setup, follow our [Student Setup Guide](https://github.com/DockYard-Academy/beta_curriculum/wiki/Student-Setup-Guide).
+The following QuickStart Guide will let you quickly try the course. For a long-term setup, follow our [Student Setup Guide](https://github.com/DockYard-Academy/curriculum/wiki/Student-Setup-Guide).
 
 The recommended installation methods for this course are from the Elixir language [website](https://elixir-lang.org/install.html#gnulinux). If you cannot see [mermaid.js](https://github.com/mermaid-js/mermaid) graphs, please ensure your Livebook version is correct. 
 
-In the future when working with multiple Elixir projects, there is a tool called [`asdf`](https://github.com/asdf-vm/asdf) that can be used to install different versions of Erlang/Elixir as defined by the [.tool-versions](https://github.com/DockYard-Academy/beta_curriculum/blob/main/.tool-versions) file in a project.
+In the future when working with multiple Elixir projects, there is a tool called [`asdf`](https://github.com/asdf-vm/asdf) that can be used to install different versions of Erlang/Elixir as defined by the [.tool-versions](https://github.com/DockYard-Academy/curriculum/blob/main/.tool-versions) file in a project.
 
 ### MacOS
 
 1. Clone the project
-   - `git clone https://github.com/DockYard-Academy/beta_curriculum.git`
+   - `git clone https://github.com/DockYard-Academy/curriculum.git`
 
 2. Install Elixir
    - `brew install elixir`
@@ -38,7 +38,7 @@ In the future when working with multiple Elixir projects, there is a tool called
 ### Windows
 
 1. Clone the project
-   - `git clone https://github.com/DockYard-Academy/beta_curriculum.git`
+   - `git clone https://github.com/DockYard-Academy/curriculum.git`
 
 2. Install Elixir
    - Download the installer [here](https://github.com/elixir-lang/elixir-windows-setup/releases/download/v2.2/elixir-websetup.exe) and run it. You will get a Windows Defender notice (don't worry) and select "More info" and "Run anyways" then follow the instructions with the default settings.
@@ -63,7 +63,7 @@ In the future when working with multiple Elixir projects, there is a tool called
 ### Linux (Ubuntu)
 
 1. Clone the project
-   - `git clone https://github.com/DockYard-Academy/beta_curriculum.git`
+   - `git clone https://github.com/DockYard-Academy/curriculum.git`
 
 2. Install Elixir
       - Add the Erlang Solutions repository
@@ -181,7 +181,7 @@ They will also have the researching and problem-solving skills necessary to expa
 throughout their career. Students will be capable of delivering high-quality, well-tested features to a production complexity codebase.
 
 ## Curriculum Outline
-The curriculum is still a rough outline subject to change and feedback. see [start.livemd](https://github.com/DockYard-Academy/beta_curriculum/blob/main/start.livemd) for a full breakdown.
+The curriculum is still a rough outline subject to change and feedback. see [start.livemd](https://github.com/DockYard-Academy/curriculum/blob/main/start.livemd) for a full breakdown.
 
 <!-- course-outline-start -->
 ## Core Syntax

--- a/exercises/_template.livemd
+++ b/exercises/_template.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## EXERCISE-NAME
 

--- a/exercises/advanced_score_tracker.livemd
+++ b/exercises/advanced_score_tracker.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/agent_journal.livemd
+++ b/exercises/agent_journal.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/anagram.livemd
+++ b/exercises/anagram.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Anagram
 

--- a/exercises/animal_generator.livemd
+++ b/exercises/animal_generator.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Animal Generator
 

--- a/exercises/battle_map.livemd
+++ b/exercises/battle_map.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Overview
 

--- a/exercises/blog_authentication.livemd
+++ b/exercises/blog_authentication.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Blog: Authentication
 

--- a/exercises/blog_comment_form.livemd
+++ b/exercises/blog_comment_form.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new)
 
 ## Blog: Comment Form
 

--- a/exercises/blog_comments.livemd
+++ b/exercises/blog_comments.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new)
 
 ## Blog: Comments
 

--- a/exercises/blog_content.livemd
+++ b/exercises/blog_content.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new)
 
 ## Blog: Blog Content
 

--- a/exercises/blog_migration.livemd
+++ b/exercises/blog_migration.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Blog: Migration
 

--- a/exercises/blog_posts.livemd
+++ b/exercises/blog_posts.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Blog: Posts
 

--- a/exercises/blog_search.livemd
+++ b/exercises/blog_search.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new)
 
 ## Blog: Search
 

--- a/exercises/blog_seeding.livemd
+++ b/exercises/blog_seeding.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new)
 
 ## Blog: Seeding
 

--- a/exercises/blog_tags.livemd
+++ b/exercises/blog_tags.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new)
 
 ## Blog Tags
 

--- a/exercises/book_changeset.livemd
+++ b/exercises/book_changeset.livemd
@@ -13,7 +13,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Book Changeset
 

--- a/exercises/book_search.livemd
+++ b/exercises/book_search.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Book Search
 

--- a/exercises/caesar_cypher.livemd
+++ b/exercises/caesar_cypher.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Caesar Cypher
 

--- a/exercises/card_counting.livemd
+++ b/exercises/card_counting.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/command_line_family_tree.livemd
+++ b/exercises/command_line_family_tree.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Command Line Family Folders
 

--- a/exercises/common_components.livemd
+++ b/exercises/common_components.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Common Components
 

--- a/exercises/concurrent_word_count.livemd
+++ b/exercises/concurrent_word_count.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Concurrent Word Count
 

--- a/exercises/consumable_protocol.livemd
+++ b/exercises/consumable_protocol.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Overview
 

--- a/exercises/counting_votes.livemd
+++ b/exercises/counting_votes.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Counting Votes
 

--- a/exercises/custom_assertions.livemd
+++ b/exercises/custom_assertions.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Custom Assertions
 

--- a/exercises/custom_enum_with_recursion.livemd
+++ b/exercises/custom_enum_with_recursion.livemd
@@ -13,7 +13,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Custom Enum With Recursion
 

--- a/exercises/custom_enum_with_reduce.livemd
+++ b/exercises/custom_enum_with_reduce.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Custom Enum With Reduce
 

--- a/exercises/deployment.livemd
+++ b/exercises/deployment.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new)
 
 ## Deploy
 

--- a/exercises/deprecated_anagram_solver.livemd
+++ b/exercises/deprecated_anagram_solver.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Anagram Solver
 

--- a/exercises/deprecated_arithmetic.livemd
+++ b/exercises/deprecated_arithmetic.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/deprecated_benchmarks.livemd
+++ b/exercises/deprecated_benchmarks.livemd
@@ -13,7 +13,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/deprecated_bingo_winner.livemd
+++ b/exercises/deprecated_bingo_winner.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Bingo Winner
 

--- a/exercises/deprecated_blog_setup.livemd
+++ b/exercises/deprecated_blog_setup.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Blog: Posts
 

--- a/exercises/deprecated_bomb_defusal.livemd
+++ b/exercises/deprecated_bomb_defusal.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/deprecated_candy_store.livemd
+++ b/exercises/deprecated_candy_store.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Create A New Mix Project
 

--- a/exercises/deprecated_capstone_project_mock.livemd
+++ b/exercises/deprecated_capstone_project_mock.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new)
 
 ## Capstone Project
 

--- a/exercises/deprecated_character_generator.livemd
+++ b/exercises/deprecated_character_generator.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/deprecated_classified.livemd
+++ b/exercises/deprecated_classified.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Classified
 

--- a/exercises/deprecated_currency_conversion.livemd
+++ b/exercises/deprecated_currency_conversion.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Currency Conversion
 

--- a/exercises/deprecated_distributed_rock_paper_scissors.livemd
+++ b/exercises/deprecated_distributed_rock_paper_scissors.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Overview
 

--- a/exercises/deprecated_drill-enum1-replace-nils.livemd
+++ b/exercises/deprecated_drill-enum1-replace-nils.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Purpose
 

--- a/exercises/deprecated_drill-enum2-replace-nils.livemd
+++ b/exercises/deprecated_drill-enum2-replace-nils.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Purpose
 

--- a/exercises/deprecated_drill-reduce-replace-nils.livemd
+++ b/exercises/deprecated_drill-reduce-replace-nils.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Purpose
 

--- a/exercises/deprecated_journal.livemd
+++ b/exercises/deprecated_journal.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Create A New Mix Project
 

--- a/exercises/deprecated_journal_cli.livemd
+++ b/exercises/deprecated_journal_cli.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/deprecated_livebook_recovery.livemd
+++ b/exercises/deprecated_livebook_recovery.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Recovering Deleted Cells
 

--- a/exercises/deprecated_mining_simulator.livemd
+++ b/exercises/deprecated_mining_simulator.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/deprecated_mix_math.livemd
+++ b/exercises/deprecated_mix_math.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/deprecated_number_wordle.livemd
+++ b/exercises/deprecated_number_wordle.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Number Wordle
 

--- a/exercises/deprecated_personality_quiz_script.livemd
+++ b/exercises/deprecated_personality_quiz_script.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Personality Test
 

--- a/exercises/deprecated_phone_parsing.livemd
+++ b/exercises/deprecated_phone_parsing.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Phone Parsing
 

--- a/exercises/deprecated_pokemon_protocols.livemd
+++ b/exercises/deprecated_pokemon_protocols.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Overview
 

--- a/exercises/deprecated_portfolio_blog_images.livemd
+++ b/exercises/deprecated_portfolio_blog_images.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new)
 
 ## Images
 

--- a/exercises/deprecated_portfolio_blog_live_search.livemd
+++ b/exercises/deprecated_portfolio_blog_live_search.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new)
 
 ## Blog Page
 

--- a/exercises/deprecated_portfolio_home_page.livemd
+++ b/exercises/deprecated_portfolio_home_page.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Home Page
 

--- a/exercises/deprecated_portfolio_mock.livemd
+++ b/exercises/deprecated_portfolio_mock.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new)
 
 ## Styled Portfolio
 

--- a/exercises/deprecated_public_chat_api.livemd
+++ b/exercises/deprecated_public_chat_api.livemd
@@ -14,7 +14,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Public Chat API
 

--- a/exercises/deprecated_rock_paper_scissors_genserver.livemd
+++ b/exercises/deprecated_rock_paper_scissors_genserver.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Rock Paper Scissors Genserver
 

--- a/exercises/deprecated_rubber_ducky.livemd
+++ b/exercises/deprecated_rubber_ducky.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Rubber Ducky
 

--- a/exercises/deprecated_school_grades.livemd
+++ b/exercises/deprecated_school_grades.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Must Register
 

--- a/exercises/deprecated_snowman_script.livemd
+++ b/exercises/deprecated_snowman_script.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Overview
 

--- a/exercises/deprecated_sublist.livemd
+++ b/exercises/deprecated_sublist.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Sublist
 
@@ -47,7 +47,7 @@ end
 ```
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Mark As Completed
 

--- a/exercises/deprecated_timed_typer.livemd
+++ b/exercises/deprecated_timed_typer.livemd
@@ -3,7 +3,7 @@
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/deprecated_todo_list.livemd
+++ b/exercises/deprecated_todo_list.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Create A New Mix Project
 
@@ -109,7 +109,7 @@ Here are some debugging tips to consider.
 * Ensure that the PostgreSQL service is running.
 * Ensure that your PostgreSQL username and password match.
 
-If you are stuck, you can speak with your instructor or classmates. You can also [raise an issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+If you are stuck, you can speak with your instructor or classmates. You can also [raise an issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 on the DockYard Academy github with an explanation of your error.
 
 ## Todo List

--- a/exercises/deprecated_video_game_spawner.livemd
+++ b/exercises/deprecated_video_game_spawner.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/document_tools.livemd
+++ b/exercises/document_tools.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Document Tools
 

--- a/exercises/dominoes.livemd
+++ b/exercises/dominoes.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Dominoe
 

--- a/exercises/drill-patternmatching-replace-nils.livemd
+++ b/exercises/drill-patternmatching-replace-nils.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Purpose
 

--- a/exercises/email_validation.livemd
+++ b/exercises/email_validation.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Email Validation
 

--- a/exercises/factorial.livemd
+++ b/exercises/factorial.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Factorial
 

--- a/exercises/family_tree.livemd
+++ b/exercises/family_tree.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Family Tree
 

--- a/exercises/fibonacci.livemd
+++ b/exercises/fibonacci.livemd
@@ -13,7 +13,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/fibonacci_challenge.livemd
+++ b/exercises/fibonacci_challenge.livemd
@@ -13,7 +13,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/file_drills.livemd
+++ b/exercises/file_drills.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## File Drills
 

--- a/exercises/file_search.livemd
+++ b/exercises/file_search.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Mastery
 

--- a/exercises/file_system_todo_app.livemd
+++ b/exercises/file_system_todo_app.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Overview
 

--- a/exercises/filter_values_by_type.livemd
+++ b/exercises/filter_values_by_type.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Filter Values By Type
 

--- a/exercises/fizzbuzz.livemd
+++ b/exercises/fizzbuzz.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## FizzBuzz
 

--- a/exercises/fun_formulas.livemd
+++ b/exercises/fun_formulas.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/games_benchmarking.livemd
+++ b/exercises/games_benchmarking.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Games: Benchmarking
 

--- a/exercises/games_documentation_and_static_analysis.livemd
+++ b/exercises/games_documentation_and_static_analysis.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Games: Documentation & DocTesting
 

--- a/exercises/games_guessing_game.livemd
+++ b/exercises/games_guessing_game.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Games: Guessing Game
 

--- a/exercises/games_menu.livemd
+++ b/exercises/games_menu.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/games_rock_paper_scissors.livemd
+++ b/exercises/games_rock_paper_scissors.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Games: Rock Paper Scissors
 

--- a/exercises/games_score_tracker.livemd
+++ b/exercises/games_score_tracker.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/games_setup.livemd
+++ b/exercises/games_setup.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Create A New Mix Project
 

--- a/exercises/games_supervised_score_tracker.livemd
+++ b/exercises/games_supervised_score_tracker.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/games_supervisor_setup.livemd
+++ b/exercises/games_supervisor_setup.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Games: Supervisor Setup
 

--- a/exercises/games_wordle.livemd
+++ b/exercises/games_wordle.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Games: Wordle
 

--- a/exercises/github_collab.livemd
+++ b/exercises/github_collab.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Collab
 

--- a/exercises/github_engineering_journal.livemd
+++ b/exercises/github_engineering_journal.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Engineering Journal
 

--- a/exercises/group_project_blog.livemd
+++ b/exercises/group_project_blog.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Group Project: Blog
 

--- a/exercises/group_project_blog_presentation.livemd
+++ b/exercises/group_project_blog_presentation.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Group Project Review
 

--- a/exercises/guessing_games.livemd
+++ b/exercises/guessing_games.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Guess the Word
 

--- a/exercises/habit_tracker.livemd
+++ b/exercises/habit_tracker.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/home_page.livemd
+++ b/exercises/home_page.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Home Page
 

--- a/exercises/in-memory_todo_list.livemd
+++ b/exercises/in-memory_todo_list.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## In-Memory Todo List
 

--- a/exercises/inventory_management.livemd
+++ b/exercises/inventory_management.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## ETS Inventory
 

--- a/exercises/itinerary.livemd
+++ b/exercises/itinerary.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Itinerary
 

--- a/exercises/lazy_product_filters.livemd
+++ b/exercises/lazy_product_filters.livemd
@@ -14,7 +14,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Lazy Product Filters
 

--- a/exercises/lucas_numbers.livemd
+++ b/exercises/lucas_numbers.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Lucas Numbers
 

--- a/exercises/mad_libs.livemd
+++ b/exercises/mad_libs.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Madlibs
 

--- a/exercises/mailbox_server.livemd
+++ b/exercises/mailbox_server.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Mailbox Server
 

--- a/exercises/mapset_drills.livemd
+++ b/exercises/mapset_drills.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## MapSet Drills
 

--- a/exercises/mapset_product_filters.livemd
+++ b/exercises/mapset_product_filters.livemd
@@ -14,7 +14,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## MapSet Product Filters
 

--- a/exercises/math_game.livemd
+++ b/exercises/math_game.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Math Game
 

--- a/exercises/math_module_testing.livemd
+++ b/exercises/math_module_testing.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/math_with_guards.livemd
+++ b/exercises/math_with_guards.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Math
 

--- a/exercises/math_with_protocols.livemd
+++ b/exercises/math_with_protocols.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Math With Protocols
 

--- a/exercises/mazes.livemd
+++ b/exercises/mazes.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/measurements.livemd
+++ b/exercises/measurements.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Measurements
 

--- a/exercises/message_validation.livemd
+++ b/exercises/message_validation.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Message Validation
 

--- a/exercises/meta_math.livemd
+++ b/exercises/meta_math.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## MetaMath
 

--- a/exercises/metric_conversion.livemd
+++ b/exercises/metric_conversion.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Metric Conversion
 

--- a/exercises/monster_spawner.livemd
+++ b/exercises/monster_spawner.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/named_number_lists.livemd
+++ b/exercises/named_number_lists.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/naming_numbers.livemd
+++ b/exercises/naming_numbers.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/number_finder.livemd
+++ b/exercises/number_finder.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Number Finder
 

--- a/exercises/palindrome.livemd
+++ b/exercises/palindrome.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Palindrome
 

--- a/exercises/pascals_triangle.livemd
+++ b/exercises/pascals_triangle.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/phoenix_drills.livemd
+++ b/exercises/phoenix_drills.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Phoenix Drills
 

--- a/exercises/phone_number_parsing.livemd
+++ b/exercises/phone_number_parsing.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Phone Number Parsing
 

--- a/exercises/pokemon_api.livemd
+++ b/exercises/pokemon_api.livemd
@@ -14,7 +14,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Mastery
 

--- a/exercises/pokemon_battle.livemd
+++ b/exercises/pokemon_battle.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Overview
 

--- a/exercises/pokemon_server.livemd
+++ b/exercises/pokemon_server.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/portfolio.livemd
+++ b/exercises/portfolio.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Mastery
 

--- a/exercises/process_drills.livemd
+++ b/exercises/process_drills.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Process Drills
 

--- a/exercises/process_mailbox.livemd
+++ b/exercises/process_mailbox.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Process Mailbox
 

--- a/exercises/product_filters.livemd
+++ b/exercises/product_filters.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Product Filters
 

--- a/exercises/rock_paper_scissors.livemd
+++ b/exercises/rock_paper_scissors.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/rock_paper_scissors_lizard_spock.livemd
+++ b/exercises/rock_paper_scissors_lizard_spock.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Rock Paper Scissors Lizard Spock
 

--- a/exercises/rollable_expressions.livemd
+++ b/exercises/rollable_expressions.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Rollable Expressions
 

--- a/exercises/rpg_dialogue.livemd
+++ b/exercises/rpg_dialogue.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Overview
 

--- a/exercises/rps_guards.livemd
+++ b/exercises/rps_guards.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Rock Paper Scissors Guards
 

--- a/exercises/rps_pattern_matching.livemd
+++ b/exercises/rps_pattern_matching.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Rock Paper Scissors Using Pattern Matching
 

--- a/exercises/rubix_cube.livemd
+++ b/exercises/rubix_cube.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Rubix's Cube
 

--- a/exercises/saferange.livemd
+++ b/exercises/saferange.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## A Safe Range Function
 

--- a/exercises/save_game.livemd
+++ b/exercises/save_game.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Save Game
 

--- a/exercises/score_tracker.livemd
+++ b/exercises/score_tracker.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Score Tracker
 

--- a/exercises/shopping_list.livemd
+++ b/exercises/shopping_list.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/exercises/sign_up_form.livemd
+++ b/exercises/sign_up_form.livemd
@@ -13,7 +13,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## User Changeset
 

--- a/exercises/spoonacular_recipe_api.livemd
+++ b/exercises/spoonacular_recipe_api.livemd
@@ -14,7 +14,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Spoonacular Recipe API
 

--- a/exercises/sql_drills.livemd
+++ b/exercises/sql_drills.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## SQL Drills
 

--- a/exercises/stack.livemd
+++ b/exercises/stack.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Tested Stack
 

--- a/exercises/stack_server.livemd
+++ b/exercises/stack_server.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Stack
 

--- a/exercises/stream_drills.livemd
+++ b/exercises/stream_drills.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Stream Drills
 

--- a/exercises/supervised_stack.livemd
+++ b/exercises/supervised_stack.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Supervised Stack
 

--- a/exercises/supervisor_and_genserver_drills.livemd
+++ b/exercises/supervisor_and_genserver_drills.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Drills
 

--- a/exercises/tailwind_css_components.livemd
+++ b/exercises/tailwind_css_components.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Tailwind Components
 

--- a/exercises/task_drills.livemd
+++ b/exercises/task_drills.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Task Drills
 

--- a/exercises/tic-tac-toe.livemd
+++ b/exercises/tic-tac-toe.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Overview
 

--- a/exercises/time_converting.livemd
+++ b/exercises/time_converting.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Time Converting
 

--- a/exercises/timeline.livemd
+++ b/exercises/timeline.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Timeline
 

--- a/exercises/timer.livemd
+++ b/exercises/timer.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Timer
 

--- a/exercises/traffic_light_server.livemd
+++ b/exercises/traffic_light_server.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Traffic Light Server
 

--- a/exercises/treasure_matching.livemd
+++ b/exercises/treasure_matching.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Treasure Matching
 

--- a/exercises/typespec_drills.livemd
+++ b/exercises/typespec_drills.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Typespec Drills
 

--- a/exercises/weighted_voting.livemd
+++ b/exercises/weighted_voting.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Weighted Voting
 

--- a/exercises/with_points.livemd
+++ b/exercises/with_points.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## With Points
 

--- a/reading/advanced_pattern_matching.livemd
+++ b/reading/advanced_pattern_matching.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/agents_and_ets.livemd
+++ b/reading/agents_and_ets.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/apis.livemd
+++ b/reading/apis.livemd
@@ -14,7 +14,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Review Questions
 

--- a/reading/arithmetic.livemd
+++ b/reading/arithmetic.livemd
@@ -14,7 +14,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/async_messages.livemd
+++ b/reading/async_messages.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/atoms.livemd
+++ b/reading/atoms.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/benchmarking.livemd
+++ b/reading/benchmarking.livemd
@@ -13,7 +13,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/big_o_notation.livemd
+++ b/reading/big_o_notation.livemd
@@ -22,7 +22,7 @@ end
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/book_search_authors.livemd
+++ b/reading/book_search_authors.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new)
 
 ## Setup
 

--- a/reading/book_search_book_content.livemd
+++ b/reading/book_search_book_content.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new)
 
 ## Review Questions
 

--- a/reading/book_search_book_form.livemd
+++ b/reading/book_search_book_form.livemd
@@ -13,7 +13,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/book_search_books.livemd
+++ b/reading/book_search_books.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new)
 
 ## Setup
 

--- a/reading/book_search_deployment.livemd
+++ b/reading/book_search_deployment.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new)
 
 ## Review Questions
 

--- a/reading/book_search_seeding.livemd
+++ b/reading/book_search_seeding.livemd
@@ -14,7 +14,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/book_search_tags.livemd
+++ b/reading/book_search_tags.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new)
 
 ## Review Questions
 

--- a/reading/booleans.livemd
+++ b/reading/booleans.livemd
@@ -13,7 +13,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/built-in_modules.livemd
+++ b/reading/built-in_modules.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/capstone_project_guide.livemd
+++ b/reading/capstone_project_guide.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/code_editors.livemd
+++ b/reading/code_editors.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/command_line.livemd
+++ b/reading/command_line.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/comments.livemd
+++ b/reading/comments.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/comparison_operators.livemd
+++ b/reading/comparison_operators.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/comprehensions.livemd
+++ b/reading/comprehensions.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/computer_hardware.livemd
+++ b/reading/computer_hardware.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/control_flow.livemd
+++ b/reading/control_flow.livemd
@@ -13,7 +13,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/credo.livemd
+++ b/reading/credo.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/datetime.livemd
+++ b/reading/datetime.livemd
@@ -13,7 +13,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/deprecated_behaviours.livemd
+++ b/reading/deprecated_behaviours.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/deprecated_binary.livemd
+++ b/reading/deprecated_binary.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/deprecated_book_form.livemd
+++ b/reading/deprecated_book_form.livemd
@@ -13,7 +13,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/deprecated_book_search_books_constraint.livemd
+++ b/reading/deprecated_book_search_books_constraint.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new)
 
 ## Setup
 

--- a/reading/deprecated_divide_and_conquer.livemd
+++ b/reading/deprecated_divide_and_conquer.livemd
@@ -13,7 +13,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/deprecated_ecto.livemd
+++ b/reading/deprecated_ecto.livemd
@@ -13,7 +13,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/deprecated_erlang_atoms.livemd
+++ b/reading/deprecated_erlang_atoms.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/deprecated_phoenix_and_ecto_relationships.livemd
+++ b/reading/deprecated_phoenix_and_ecto_relationships.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new)
 
 ## Setup
 

--- a/reading/deprecated_pipe_operator.livemd
+++ b/reading/deprecated_pipe_operator.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/deprecated_polymorphism.livemd
+++ b/reading/deprecated_polymorphism.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/deprecated_scripts.livemd
+++ b/reading/deprecated_scripts.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/deprecated_supervised_mix_project.livemd
+++ b/reading/deprecated_supervised_mix_project.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/doctests.livemd
+++ b/reading/doctests.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/ecto_changeset.livemd
+++ b/reading/ecto_changeset.livemd
@@ -13,7 +13,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/enum.livemd
+++ b/reading/enum.livemd
@@ -14,7 +14,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/exdoc.livemd
+++ b/reading/exdoc.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/executables.livemd
+++ b/reading/executables.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/exunit.livemd
+++ b/reading/exunit.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/exunit_with_mix.livemd
+++ b/reading/exunit_with_mix.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/file.livemd
+++ b/reading/file.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/functions.livemd
+++ b/reading/functions.livemd
@@ -13,7 +13,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/generic_server.livemd
+++ b/reading/generic_server.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/git.livemd
+++ b/reading/git.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 
@@ -82,8 +82,8 @@ Out of the box, GitHub may ask you to enter your user credentials when running c
 
 ## Raising An Issue
 
-Anyone can raise an issue on a public GitHub project. For example, you can [raise an issue](https://github.com/DockYard-Academy/beta_curriculum/issues) by going to
-the issues tab on the [GitHub Page](https://github.com/DockYard-Academy/beta_curriculum) of this curriculum and clicking **New Issue**.
+Anyone can raise an issue on a public GitHub project. For example, you can [raise an issue](https://github.com/DockYard-Academy/curriculum/issues) by going to
+the issues tab on the [GitHub Page](https://github.com/DockYard-Academy/curriculum) of this curriculum and clicking **New Issue**.
 
 Please raise an issue or speak with your instructor if you encounter a problem with the curriculum.
 

--- a/reading/guards.livemd
+++ b/reading/guards.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/html_css.livemd
+++ b/reading/html_css.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/iex.livemd
+++ b/reading/iex.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/io.livemd
+++ b/reading/io.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/keyword_lists.livemd
+++ b/reading/keyword_lists.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/lists.livemd
+++ b/reading/lists.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/lists_vs_tuples.livemd
+++ b/reading/lists_vs_tuples.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/livebook.livemd
+++ b/reading/livebook.livemd
@@ -13,7 +13,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 
@@ -101,7 +101,7 @@ You can create an Elixir cell anywhere throughout this course if you want to exp
 
 To create an Elixir cell, hover your cursor between two cells and press the `+Code` button.
 
-Livebook may change this UI, so if this is instruction is no longer accurate please speak to your instructor and/or [Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+Livebook may change this UI, so if this is instruction is no longer accurate please speak to your instructor and/or [Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 <!-- livebook:{"break_markdown":true} -->
 

--- a/reading/liveview.livemd
+++ b/reading/liveview.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Review Questions
 

--- a/reading/maps.livemd
+++ b/reading/maps.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/maps_mapsets_keyword_lists.livemd
+++ b/reading/maps_mapsets_keyword_lists.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/match_operator.livemd
+++ b/reading/match_operator.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/metaprogramming.livemd
+++ b/reading/metaprogramming.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/mix.livemd
+++ b/reading/mix.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/modules.livemd
+++ b/reading/modules.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/newsletter.livemd
+++ b/reading/newsletter.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/non_enumerables.livemd
+++ b/reading/non_enumerables.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/phoenix_1.6.livemd
+++ b/reading/phoenix_1.6.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/phoenix_1.7.livemd
+++ b/reading/phoenix_1.7.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/phoenix_and_ecto.livemd
+++ b/reading/phoenix_and_ecto.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/phoenix_authentication.livemd
+++ b/reading/phoenix_authentication.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/pic_chat_image_upload.livemd
+++ b/reading/pic_chat_image_upload.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/pic_chat_infinite_scroll.livemd
+++ b/reading/pic_chat_infinite_scroll.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/pic_chat_messages.livemd
+++ b/reading/pic_chat_messages.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/pic_chat_pub_sub.livemd
+++ b/reading/pic_chat_pub_sub.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/processes.livemd
+++ b/reading/processes.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/protocols.livemd
+++ b/reading/protocols.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/ranges.livemd
+++ b/reading/ranges.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/rdbms.livemd
+++ b/reading/rdbms.livemd
@@ -14,7 +14,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 
@@ -118,7 +118,7 @@ postgres-# \q
 Unfortunately, It's common to run into issues when setting up PostgreSQL. Every student
 has a different environment, so it's difficult to anticipate issues you may encounter.
 
-If you get stuck, please speak to a classmate, speak to your instructor, or [raise an issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=) on the Dockyard Academy repository. You may also attempt to debug the issue by researching the error message and finding recommendations online.
+If you get stuck, please speak to a classmate, speak to your instructor, or [raise an issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=) on the Dockyard Academy repository. You may also attempt to debug the issue by researching the error message and finding recommendations online.
 
 We recommend caution when running commands found on the Internet, as they can cause further issues. We also recommend you keep a journal of everything you try. This journal can help you and others identify issues and may help if you encounter the same problem in the future.
 

--- a/reading/recursion.livemd
+++ b/reading/recursion.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/reduce.livemd
+++ b/reading/reduce.livemd
@@ -14,7 +14,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/regex.livemd
+++ b/reading/regex.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/regex.livemd
+++ b/reading/regex.livemd
@@ -26,7 +26,7 @@ Upon completing this lesson, a student should be able to answer the following qu
 
 * What are some common use cases for Regular Expressions?
 * How can we use Regular Expressions to manipulate strings?
-* How can we experiment and build Regular Expressions using [Regexr]([Regexr](https://regexr.com/))?
+* How can we experiment and build Regular Expressions using [Regexr](https://regexr.com/)?
 
 ## Overview
 

--- a/reading/schemas_and_migrations.livemd
+++ b/reading/schemas_and_migrations.livemd
@@ -13,7 +13,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Review Questions
 

--- a/reading/start_here.livemd
+++ b/reading/start_here.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 
@@ -89,7 +89,7 @@ If you are unfamiliar with Git and GitHub, consider reading the [Lesson on Git](
 
 ## Troubleshooting and Support
 
-It's common to find yourself blocked and needing help when learning new concepts. This can be especially challenging for a self-led learner. If you need support or encounter any issues with a lesson, there is a [Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=) button you can use to get support.
+It's common to find yourself blocked and needing help when learning new concepts. This can be especially challenging for a self-led learner. If you need support or encounter any issues with a lesson, there is a [Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=) button you can use to get support.
 
 In addition, students in a DockYard Academy cohort (paid) get direct access to a community of peers and mentors on the DockYard Academy Discord. Post on the `#questions-and-answers` channel whenever you need support.
 

--- a/reading/streams.livemd
+++ b/reading/streams.livemd
@@ -13,7 +13,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/strings.livemd
+++ b/reading/strings.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/strings_and_binaries.livemd
+++ b/reading/strings_and_binaries.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/structs.livemd
+++ b/reading/structs.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/supervised_mix_project.livemd
+++ b/reading/supervised_mix_project.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/supervisors.livemd
+++ b/reading/supervisors.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Review Questions
 

--- a/reading/tailwind.livemd
+++ b/reading/tailwind.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new)
 
 ## Setup
 

--- a/reading/task.livemd
+++ b/reading/task.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/task_supervisor.livemd
+++ b/reading/task_supervisor.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/testing_genservers.livemd
+++ b/reading/testing_genservers.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Review Questions
 

--- a/reading/tuples.livemd
+++ b/reading/tuples.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/typespecs.livemd
+++ b/reading/typespecs.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/web_servers.livemd
+++ b/reading/web_servers.livemd
@@ -13,7 +13,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/reading/with.livemd
+++ b/reading/with.livemd
@@ -12,7 +12,7 @@ Mix.install([
 ## Navigation
 
 [Return Home](../start.livemd)<span style="padding: 0 30px"></span>
-[Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
+[Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=)
 
 ## Setup
 

--- a/start.livemd
+++ b/start.livemd
@@ -11,7 +11,7 @@ flowchart
 Welcome!
 ```
 
-If you do not see the box above, or if you encounter any issues with this course, please ensure you have correctly followed the [Student Setup Guide](https://github.com/DockYard-Academy/beta_curriculum/wiki/Student-Setup-Guide) or [Report An Issue](https://github.com/DockYard-Academy/beta_curriculum/issues/new?assignees=&labels=&template=issue.md&title=) to receive help.
+If you do not see the box above, or if you encounter any issues with this course, please ensure you have correctly followed the [Student Setup Guide](https://github.com/DockYard-Academy/curriculum/wiki/Student-Setup-Guide) or [Report An Issue](https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=) to receive help.
 
 <!-- livebook:{"break_markdown":true} -->
 


### PR DESCRIPTION
GitHub redirects beta_curriculum to curriculum but if this is the final name of the repo having it match sure feels good!
This is based off #898 as we're changing the same link thats edited in that PR once more.