### PR TITLE
Fix formating shortcuts for mac

### DIFF
--- a/reading/livebook.livemd
+++ b/reading/livebook.livemd
@@ -203,9 +203,9 @@ Sometimes order of evaluation can cause issues in Exercises by using a stale ver
 
 ## Formatting
 
-You can format Elixir code using the <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>I</kbd> (Windows & Linux) Keybinding or <kbd>SHIFT</kbd>+<kbd>OPTION</kbd>+<kbd>I</kbd> (MacOS).
+You can format Elixir code using the <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>I</kbd> (Windows & Linux) Keybinding or <kbd>SHIFT</kbd>+<kbd>OPTION</kbd>+<kbd>F</kbd> (MacOS).
 
-Try uncommenting the following code (Remove the `#` character) then press <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>I</kbd> (Windows & Linux) or <kbd>SHIFT</kbd>+<kbd>OPTION</kbd>+<kbd>I</kbd> (MacOS) to format the code.
+Try uncommenting the following code (Remove the `#` character) then press <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>I</kbd> (Windows & Linux) or <kbd>SHIFT</kbd>+<kbd>OPTION</kbd>+<kbd>F</kbd> (MacOS) to format the code.
 
 Notice that the `1 + 1` code moves to the left.
 


### PR DESCRIPTION
Dunno about the windows/linux shortcuts but the previously correct cmd+option+F is still valid on macOS in livebook v0.9.0.