### PR TITLE
Fixes percent calculation

### DIFF
--- a/exercises/fun_formulas.livemd
+++ b/exercises/fun_formulas.livemd
@@ -35,7 +35,7 @@ For example if we complete `7` out of `10` items, we would be `70.0%` complete.
 <!-- livebook:{"force_markdown":true} -->
 
 ```elixir
-7 / 10 # 70.0
+(7 / 10) * 100 # 70.0
 ```
 
 Use arithmetic operators to determine the **percentage** given we have completed `12` out of `42` items.
@@ -47,7 +47,7 @@ Use arithmetic operators to determine the **percentage** given we have completed
 actual = 12
 total = 42
 
-actual / total
+(actual / total) * 100
 ```
 
 </details>


### PR DESCRIPTION
The example solution does not include the multiplication with 100 and could be confusing as this is in the percent calculation formula right above.