### PR TITLE
Fixed minor typo in Supervisors 

### DIFF
--- a/reading/supervisors.livemd
+++ b/reading/supervisors.livemd
@@ -72,7 +72,7 @@ Process.sleep(100)
 When a linked process crashes, it will also crashed the process that spawned it. Uncomment the code below, and you'll see it crashes the current Livebook process. Re-comment the code when finished.
 
 ```elixir
-# Spawn_link(fn -> Raise "error" End)
+# spawn_link(fn -> raise "error" end)
 ```
 
 That means if we start a [GenServer](https://hexdocs.pm/elixir/GenServer.html) (or other process) **unsupervised** it will raise an error if it crashes.


### PR DESCRIPTION
Changed this code # Spawn_link(fn -> Raise "error" End) to be lower case