### PR TITLE
Clean up escaping string interpolation example

### DIFF
--- a/reading/strings.livemd
+++ b/reading/strings.livemd
@@ -199,7 +199,7 @@ IO.puts(string)
 There are other special characters such as backslashes `\`, or interpolation syntax that you might want to escape.
 
 ```elixir
-string = "Use \#\{\} to interpolate a value in a string"
+string = "Use \#{} to interpolate a value in a string"
 
 IO.puts(string)
 ```


### PR DESCRIPTION
The whole special character being escaped is the string interpolation`#{}`; you can think of this as escaping the leading hash symbol leaves everything else as just normal characters or as escaping the whole interpolation token. It is unnecessary to escape each individual character in the string interpolation.   You wouldn't need to do `\#\{\2\+\2\}` to include `#{2+2}` in a string rather that have Elixir interpolate it and return 4, `\#{2+2}` will do that. The whole interpolation is escaped with a single backslash.