### PR TITLE
Convert proportion to percent

### DIFF
--- a/exercises/habit_tracker.livemd
+++ b/exercises/habit_tracker.livemd
@@ -128,7 +128,7 @@ Remember that you can calculate percentage with $\frac{points}{goal} * 100$
 
 ```elixir
 goal = 40
-(small + medium) / goal
+((small + medium) / goal) * 100
 ```
 
 Or you might consider binding `points` as a variable.
@@ -137,7 +137,7 @@ Or you might consider binding `points` as a variable.
 ```elixir
 goal = 40
 points = small + medium 
-points / goal
+(points / goal) * 100
 ```
 
 </details>


### PR DESCRIPTION
You're asking for percent and give a reminder to multiply by 100 to get percent but the suggested solution leave the proportion.
You may choose not to include the parenthesis that I did; I like to explicitly indicate the expected order of operations as formulas are easier for me to read them that way.