### PR TITLE
datetime.livemd kino dependency fix

### DIFF
--- a/reading/datetime.livemd
+++ b/reading/datetime.livemd
@@ -3,7 +3,7 @@
 ```elixir
 Mix.install([
   {:jason, "~> 1.4"},
-  {:kino, "~> 0.9"},
+  {:kino, "~> 0.9", override: true},
   {:timex, "~> 3.7.11"},
   {:youtube, github: "brooklinjazz/youtube"},
   {:hidden_cell, github: "brooklinjazz/hidden_cell"}


### PR DESCRIPTION
Missing "override: true" on kino dependency