### PR TITLE
Update file_drills.livemd

### DIFF
--- a/exercises/file_drills.livemd
+++ b/exercises/file_drills.livemd
@@ -134,7 +134,7 @@ Use [File.stream!/3](https://hexdocs.pm/elixir/File.html#stream!/3) to read each
 
 ```
 
-Use [File.stream!/3](https://hexdocs.pm/elixir/File.html#stream!/3) and [Stream.filter/2](https://hexdocs.pm/elixir/Stream.html#filter/2) to filter in lines from `multi-line.txt` that contain numbers less than or equal to `3`.
+Use [File.stream!/3](https://hexdocs.pm/elixir/File.html#stream!/3) and [Stream.filter/2](https://hexdocs.pm/elixir/Stream.html#filter/2) to filter in lines from `multi-line.txt` that contain numbers less than `3`.
 
 Use [File.write/3](https://hexdocs.pm/elixir/File.html#write/3) to re-write `multi-line.txt` with only the filtered lines.
 


### PR DESCRIPTION
### what changes have made and why

Solved issue #844 
- Changed the text ```numbers less or equal to 3``` to ```numbers less 3``` in file ```exercises/file_drills.livemd``` as stated in the issue.