### PR TITLE
Add unique index for title

### DIFF
--- a/reading/phoenix_and_ecto.livemd
+++ b/reading/phoenix_and_ecto.livemd
@@ -246,6 +246,7 @@ defmodule Blog.Repo.Migrations.CreatePosts do
 
       timestamps()
     end
+    create unique_index(:posts, [:title])
   end
 end
 ```


### PR DESCRIPTION
in ecto docs it says
> The unique constraint works by relying on the database to check if the unique constraint has been violated or not and, if so, Ecto converts it into a changeset error.

so if you do not do this it will not show error when you insert new post with title already exists and just inserted