### PR TITLE
fix: expected output of Enum.map to str collection in Enum reading

### DIFF
--- a/reading/enum.livemd
+++ b/reading/enum.livemd
@@ -369,7 +369,7 @@ Use [Enum.map/2](https://hexdocs.pm/elixir/Enum.html#map/2) to convert a list of
 
 ```elixir
 # Expected Output
-["1", "2", "3", "4", "5", "6", "7", "8", "9"]
+["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]
 ```
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">


### PR DESCRIPTION
> Use [Enum.map/2](https://hexdocs.pm/elixir/Enum.html#map/2) to convert a list of integers from 1 to 10 to strings.