### PR TITLE
Map notebooks

### DIFF
--- a/utils/lib/notebooks.ex
+++ b/utils/lib/notebooks.ex
@@ -271,18 +271,6 @@ defmodule Utils.Notebooks do
     """
   end
 
-  defp prev(%{index: 0}), do: %{}
-
-  defp prev(notebook) do
-    Enum.at(outline_notebooks(), notebook.index - 1)
-  end
-
-  defp next(notebook) when @number_of_notebooks == notebook.index + 1, do: %{}
-
-  defp next(notebook) do
-    Enum.at(outline_notebooks(), notebook.index + 1)
-  end
-
   defp built_in_module_docs(content) do
     Regex.replace(~r/`(\w+)`/, content, fn full, module_name ->
       module = String.to_atom("Elixir." <> module_name)

--- a/utils/lib/notebooks.ex
+++ b/utils/lib/notebooks.ex
@@ -246,9 +246,6 @@ defmodule Utils.Notebooks do
   end
 
   def navigation_snippet(notebook) do
-    prev_notebook = prev(notebook)
-    next_notebook = next(notebook)
-
     # indenting results in Livebook misformatting the code.
     """
     ## Navigation
@@ -263,12 +260,12 @@ defmodule Utils.Notebooks do
     <a style="display: flex; color: #61758a; margin-left: 1rem;" href="https://github.com/DockYard-Academy/curriculum/issues/new?assignees=&labels=&template=issue.md&title=#{notebook.title}">Report An Issue</a>
     </div>
     <div style="display: flex;">
-    <i #{if prev_notebook == %{}, do: "style=\"display: none;\" "}class="ri-arrow-left-fill"></i>
-    <a style="display: flex; color: #61758a; margin-left: 1rem;" href="#{Map.get(prev_notebook, :relative_path, "")}">#{Map.get(prev_notebook, :title, "")}</a>
+    <i #{if notebook.prev_notebook == %{}, do: "style=\"display: none;\" "}class="ri-arrow-left-fill"></i>
+    <a style="display: flex; color: #61758a; margin-left: 1rem;" href="#{Map.get(notebook.prev_notebook,:relative_path, "")}">#{Map.get(notebook.prev_notebook,:name, "")}</a>
     </div>
     <div style="display: flex;">
-    <a style="display: flex; color: #61758a; margin-right: 1rem;" href="#{Map.get(next_notebook, :relative_path, "")}">#{Map.get(next_notebook, :title, "")}</a>
-    <i #{if next_notebook == %{}, do: "style=\"display: none;\" "}class="ri-arrow-right-fill"></i>
+    <a style="display: flex; color: #61758a; margin-right: 1rem;" href="#{Map.get(notebook.next_notebook,:relative_path, "")}">#{Map.get(notebook.next_notebook,:name, "")}</a>
+    <i #{if notebook.next_notebook == %{}, do: "style=\"display: none;\" "}class="ri-arrow-right-fill"></i>
     </div>
     </div>
     """

--- a/utils/lib/notebooks/notebook.ex
+++ b/utils/lib/notebooks/notebook.ex
@@ -27,13 +27,39 @@ defmodule Utils.Notebooks.Notebook do
   require Logger
 
   @doc """
+  Given a list of names and relative paths will create a list of notebook structs
+  with the next_notebook and prev_notebook attributes set according to the position 
+  of the notebook in the list.
+
+  Useful for parsing input that is read from the start.livemd file.
+  """
+  @spec map_notebooks([%{name: String.t(), relative_path: String.t()}]) :: [__MODULE__.t()]
+  def map_notebooks(nodes) do
+    [first, second | _rest] = nodes
+    first_node = Map.put(first, :next_notebook, second) |> Map.put(:prev_notebook, %{})
+
+    rest =
+      Enum.chunk_every(nodes, 3, 1)
+      |> Enum.map(fn
+        [prev, curr, next] ->
+          Map.put(curr, :prev_notebook, prev)
+          |> Map.put(:next_notebook, next)
+
+        [prev, curr] ->
+          Map.put(curr, :prev_notebook, prev)
+          |> Map.put(:next_notebook, %{})
+      end)
+
+    [first_node | rest]
+    |> Enum.map(&new!/1)
+  end
+
+  @doc """
   Create a new Notebook struct
 
   iex> Utils.Notebooks.Notebook.new!(%{index: 0, relative_path: "../reading/strings_and_binaries.livemd"})
   %Utils.Notebooks.Notebook{index: 0, relative_path: "../reading/strings_and_binaries.livemd", name: "strings_and_binaries", title: "Strings And Binaries", folder: "reading", type: :reading}
   """
-  require Logger
-
   def new!(%{relative_path: "../start.livemd"} = attrs) do
     struct!(
       __MODULE__,

--- a/utils/lib/notebooks/notebook.ex
+++ b/utils/lib/notebooks/notebook.ex
@@ -4,13 +4,27 @@ defmodule Utils.Notebooks.Notebook do
   """
   defstruct [
     :content,
-    :index,
     :name,
     :relative_path,
     :title,
     :folder,
-    :type
+    :type,
+    :next_notebook,
+    :prev_notebook
   ]
+
+  @type t :: %__MODULE__{
+          content: String.t(),
+          name: String.t(),
+          relative_path: String.t(),
+          title: String.t(),
+          folder: String.t(),
+          type: String.t(),
+          next_notebook: map(),
+          prev_notebook: map()
+        }
+
+  require Logger
 
   @doc """
   Create a new Notebook struct


### PR DESCRIPTION
Hi Brook,

I used my solution to the bonus exercise as a starting point for changing how  the notebook ordering is handled in the notebooks utilities.  I removed the index attribute from the notebook struct and added in information about each notebooks neighbors instead.  I think this will make things more flexible and it will also avoid additional list scans.

Let me know what you think.