### PR TITLE
Link refrenced 'cons cells' but, in sentence context, 'cell' needed t…

### DIFF
--- a/reading/lists.livemd
+++ b/reading/lists.livemd
@@ -164,7 +164,7 @@ In the Elixir cell below, remove `[1]` from `[1, 1, 2, 3]` to make `[1, 2, 3]`
 
 ## Head And Tail
 
-Under the hood, lists are implemented as **linked lists** where every element is a [cons cells](https://en.wikipedia.org/wiki/Cons). with a head and a tail.
+Under the hood, lists are implemented as **linked lists** where every element is a [cons cell](https://en.wikipedia.org/wiki/Cons) with a head and a tail.
 
 Let's take the example list `[2, 3]`.
 


### PR DESCRIPTION
…o be singular; also, removed mid-sentence period