### PR TITLE
Enum chapter fixes

### DIFF
--- a/reading/enum.livemd
+++ b/reading/enum.livemd
@@ -77,7 +77,7 @@ Enum.map([1, 2, 3, 4, 5], fn element -> element * 2 end)
 
 ### Enumerable
 
-Certain data types in Elixir implement the [Enumerable](https://hexdocs.pm/elixir/Enumerable.html) protocol. That means these we can enumerate through elements in these enumerable data types.
+Certain data types in Elixir implement the [Enumerable](https://hexdocs.pm/elixir/Enumerable.html) protocol. That means we can enumerate through elements in these enumerable data types.
 
 Most enumerables are collections, but not all of them. For example a range doesn't contain other elements, but it is enumerable.
 

--- a/reading/enum.livemd
+++ b/reading/enum.livemd
@@ -296,7 +296,7 @@ end)
 
 The [Enum](https://hexdocs.pm/elixir/Enum.html) module also provides other useful functions. Here are a handful of the most used.
 
-* [Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all/2) check if all elements in a collection match some condition.
+* [Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all?/2) check if all elements in a collection match some condition.
 * [Enum.any?/2](https://hexdocs.pm/elixir/Enum.html#any?/2) check if any elements in a collection match some condition.
 * [Enum.count/2](https://hexdocs.pm/elixir/Enum.html#count/2) return the number of elements in a collection collection.
 * [Enum.find/3](https://hexdocs.pm/elixir/Enum.html#find/3) return an element in a collection that matches some condition.
@@ -549,9 +549,9 @@ Enter your solution below.
 
 ## Enum.all?/2
 
-[Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all/2) checks that all elements in a collection match some condition.
+[Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all?/2) checks that all elements in a collection match some condition.
 
-[Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all/2) executes the callback function provided on each element. If every element returns truthy, then [Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all/2) returns `true`.
+[Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all?/2) executes the callback function provided on each element. If every element returns truthy, then [Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all?/2) returns `true`.
 
 <!-- livebook:{"break_markdown":true} -->
 
@@ -567,13 +567,13 @@ E --> Boolean
 Enum.all?([1, 2, 3], fn integer -> is_integer(integer) end)
 ```
 
-If a single element returns a falsy value, then [Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all/2) returns `false`.
+If a single element returns a falsy value, then [Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all?/2) returns `false`.
 
 ```elixir
 Enum.all?([1, 2, 3, "4"], fn element -> is_integer(element) end)
 ```
 
-For performance reasons, [Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all/2) will complete as soon as it finds a single element that returns a falsey value when called with the function.
+For performance reasons, [Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all?/2) will complete as soon as it finds a single element that returns a falsey value when called with the function.
 
 Notice the code below should finish very quickly because the very first element fails the condition.
 
@@ -581,7 +581,7 @@ Notice the code below should finish very quickly because the very first element 
 Enum.all?(1..10_000_000, fn integer -> is_bitstring(integer) end)
 ```
 
-If [Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all/2) must traverse the entire collection if all elements pass the condition, or if a failing element is towards the end of the list.
+If [Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all?/2) must traverse the entire collection if all elements pass the condition, or if a failing element is towards the end of the list.
 
 Notice the code below should take awhile to finish running because every element passes the condition.
 
@@ -591,7 +591,7 @@ Enum.all?(1..10_000_000, fn integer -> is_integer(integer) end)
 
 ### Your Turn
 
-Use [Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all/2) to determine if all of the `colors` in this list of colors are `:green`. You may change the value of `colors` to experiment with [Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all/2).
+Use [Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all?/2) to determine if all of the `colors` in this list of colors are `:green`. You may change the value of `colors` to experiment with [Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all?/2).
 
 ```elixir
 colors = [:green, :green, :red]

--- a/reading/enum.livemd
+++ b/reading/enum.livemd
@@ -296,7 +296,7 @@ end)
 
 The [Enum](https://hexdocs.pm/elixir/Enum.html) module also provides other useful functions. Here are a handful of the most used.
 
-* [Enum.all/2](https://hexdocs.pm/elixir/Enum.html#all/2) check if all elements in a collection match some condition.
+* [Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all/2) check if all elements in a collection match some condition.
 * [Enum.any?/2](https://hexdocs.pm/elixir/Enum.html#any?/2) check if any elements in a collection match some condition.
 * [Enum.count/2](https://hexdocs.pm/elixir/Enum.html#count/2) return the number of elements in a collection collection.
 * [Enum.find/3](https://hexdocs.pm/elixir/Enum.html#find/3) return an element in a collection that matches some condition.
@@ -549,9 +549,9 @@ Enter your solution below.
 
 ## Enum.all?/2
 
-[Enum.all/2](https://hexdocs.pm/elixir/Enum.html#all/2) checks that all elements in a collection match some condition.
+[Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all/2) checks that all elements in a collection match some condition.
 
-[Enum.all/2](https://hexdocs.pm/elixir/Enum.html#all/2) executes the callback function provided on each element. If every element returns truthy, then [Enum.all/2](https://hexdocs.pm/elixir/Enum.html#all/2) returns `true`.
+[Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all/2) executes the callback function provided on each element. If every element returns truthy, then [Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all/2) returns `true`.
 
 <!-- livebook:{"break_markdown":true} -->
 
@@ -567,13 +567,13 @@ E --> Boolean
 Enum.all?([1, 2, 3], fn integer -> is_integer(integer) end)
 ```
 
-If a single element returns a falsy value, then [Enum.all/2](https://hexdocs.pm/elixir/Enum.html#all/2) returns `false`.
+If a single element returns a falsy value, then [Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all/2) returns `false`.
 
 ```elixir
 Enum.all?([1, 2, 3, "4"], fn element -> is_integer(element) end)
 ```
 
-For performance reasons, [Enum.all/2](https://hexdocs.pm/elixir/Enum.html#all/2) will complete as soon as it finds a single element that returns a falsey value when called with the function.
+For performance reasons, [Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all/2) will complete as soon as it finds a single element that returns a falsey value when called with the function.
 
 Notice the code below should finish very quickly because the very first element fails the condition.
 
@@ -581,7 +581,7 @@ Notice the code below should finish very quickly because the very first element 
 Enum.all?(1..10_000_000, fn integer -> is_bitstring(integer) end)
 ```
 
-If [Enum.all/2](https://hexdocs.pm/elixir/Enum.html#all/2) must traverse the entire collection if all elements pass the condition, or if a failing element is towards the end of the list.
+If [Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all/2) must traverse the entire collection if all elements pass the condition, or if a failing element is towards the end of the list.
 
 Notice the code below should take awhile to finish running because every element passes the condition.
 
@@ -591,7 +591,7 @@ Enum.all?(1..10_000_000, fn integer -> is_integer(integer) end)
 
 ### Your Turn
 
-Use [Enum.all/2](https://hexdocs.pm/elixir/Enum.html#all/2) to determine if all of the `colors` in this list of colors are `:green`. You may change the value of `colors` to experiment with [Enum.all/2](https://hexdocs.pm/elixir/Enum.html#all/2).
+Use [Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all/2) to determine if all of the `colors` in this list of colors are `:green`. You may change the value of `colors` to experiment with [Enum.all?/2](https://hexdocs.pm/elixir/Enum.html#all/2).
 
 ```elixir
 colors = [:green, :green, :red]

--- a/reading/non_enumerables.livemd
+++ b/reading/non_enumerables.livemd
@@ -123,7 +123,7 @@ For example, we can split a string by every comma like so:
 String.split("a,b,c,d", ",")
 ```
 
-We can split a string into a list of characters by splitting on every empty space `""` This does create an empty string becaused of the start and the end of the list.
+We can split a string into a list of characters by splitting on every empty space `""` This does create an empty string at the start and the end of the list.
 
 ```elixir
 String.split("abcde", "")


### PR DESCRIPTION
Caught what I assume is an unintended wording. Thanks for having this curriculum open to the public!

Edit: In this same chapter (Enum), the function `Enum.all?/2` was typically (but not always) missing the question mark in markdown references to it. Updated all of those as well.