### PR TITLE
Fix typo in phoenix components section

### DIFF
--- a/exercises/phoenix_drills.livemd
+++ b/exercises/phoenix_drills.livemd
@@ -54,7 +54,7 @@ $ mix phx.new random_number --no-ecto
 
 ## Phoenix Navigation
 
-Create a Pheonix application with three pages:
+Create a Phoenix application with three pages:
 
 * Home
 * About

--- a/exercises/phoenix_follow_along_counter_app.livemd
+++ b/exercises/phoenix_follow_along_counter_app.livemd
@@ -104,7 +104,7 @@ In `lib/counter_web/router.ex` modify the existing scope with the following. We'
 scope "/", CounterWeb do
   pipe_through :browser
 
-  get "/", CounterController, :home
+  get "/", CounterController, :count
 end
 ```
 
@@ -139,6 +139,16 @@ defmodule CounterWeb.CounterHTML do
   use CounterWeb, :html
 
   embed_templates "counter_html/*"
+
+    def to_number(number_as_string) when is_binary(number_as_string) do
+    number_as_string
+    |> String.trim()
+    |> String.to_integer()
+  end
+
+  def to_number(number) do
+    number
+  end
 end
 ```
 
@@ -198,7 +208,7 @@ Add the link to the template in `counter_web/controllers/counter_html/count.html
 <h1 class="text-4xl">The current count is: <%= @count %></h1>
 
 <.link
-  navigate={~p"/?count=#{@count + 1}"}
+  navigate={~p"/?count=#{to_number(@count) + 1}"}
   class="bg-cyan-500 hover:bg-cyan-400 text-2xl p-4 mt-4 rounded-full inline-block"
 >
   Increment

--- a/exercises/phoenix_follow_along_counter_app.livemd
+++ b/exercises/phoenix_follow_along_counter_app.livemd
@@ -139,16 +139,6 @@ defmodule CounterWeb.CounterHTML do
   use CounterWeb, :html
 
   embed_templates "counter_html/*"
-
-    def to_number(number_as_string) when is_binary(number_as_string) do
-    number_as_string
-    |> String.trim()
-    |> String.to_integer()
-  end
-
-  def to_number(number) do
-    number
-  end
 end
 ```
 
@@ -209,7 +199,7 @@ Add the link to the template in `counter_web/controllers/counter_html/count.html
 
 <.link
   navigate={~p"/?count=#{to_number(@count) + 1}"}
-  class="bg-cyan-500 hover:bg-cyan-400 text-2xl p-4 mt-4 rounded-full inline-block"
+  class="inline-block p-4 mt-4 text-2xl rounded-full bg-cyan-500 hover:bg-cyan-400"
 >
   Increment
 </.link>
@@ -274,9 +264,9 @@ end
 
 For more on Phoenix, consider the following resources.
 
-* [Phoenix HexDocs](https://hexdocs.pm/phoenix/Phoenix.html)
-* [Plug HexDocs](https://hexdocs.pm/plug/readme.html)
-* [Phoenix a Web Framework for the New Web • José Valim • GOTO 2016](https://www.youtube.com/watch?v=bk3icU8iIto&ab_channel=GOTOConferences)
+- [Phoenix HexDocs](https://hexdocs.pm/phoenix/Phoenix.html)
+- [Plug HexDocs](https://hexdocs.pm/plug/readme.html)
+- [Phoenix a Web Framework for the New Web • José Valim • GOTO 2016](https://www.youtube.com/watch?v=bk3icU8iIto&ab_channel=GOTOConferences)
 
 ## Commit Your Progress
 

--- a/reading/phoenix_1.7.livemd
+++ b/reading/phoenix_1.7.livemd
@@ -50,7 +50,7 @@ Phoenix 1.7 also introduced [Verified Routes](https://hexdocs.pm/phoenix/1.7.0-r
 ~p"/home"
 ```
 
-Many projects in the Elixir ecosystem will still use Pheonix 1.6 or older. While this course focuses on Phoenix 1.7, consider reading the previous [Phoenix 1.6](./deprecated_phoenix_1.6.livemd) section to learn more about the older version.
+Many projects in the Elixir ecosystem will still use Phoenix 1.6 or older. While this course focuses on Phoenix 1.7, consider reading the previous [Phoenix 1.6](./deprecated_phoenix_1.6.livemd) section to learn more about the older version.
 
 <!-- livebook:{"break_markdown":true} -->
 

--- a/reading/phoenix_components.livemd
+++ b/reading/phoenix_components.livemd
@@ -268,7 +268,7 @@ Here's an example of a form without a changeset that sends a GET request to the 
 
 ### Internal Components
 
-[Pheonix.Component](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html) also defines several internal components.
+[Phoenix.Component](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html) also defines several internal components.
 
 For example, the `simple_form/1` component in `core_components.ex` relies on the [form/1](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#form/1) component.
 


### PR DESCRIPTION
A tiny typo in the name of `Phoenix.Component`