### PR TITLE
add missing assert in string test

### DIFF
--- a/reading/exunit.livemd
+++ b/reading/exunit.livemd
@@ -292,7 +292,7 @@ defmodule StringContainsTest do
 
   test "string contains hello" do
     string = "hello world"
-    string =~ "hello"
+    assert string =~ "hello"
   end
 end
 


### PR DESCRIPTION
The first executable test with the `=~` operator in the ExUnit reading was missing an assert function, so nothing was actually being tested.