### PR TITLE
Fixed 3 Typos

### DIFF
--- a/exercises/process_drills.livemd
+++ b/exercises/process_drills.livemd
@@ -112,7 +112,7 @@ Use [Process.send_after/4](https://hexdocs.pm/elixir/Process.html#send_after/4) 
 
 ```
 
-Use [Process.spawn/3](https://hexdocs.pm/elixir/Process.html#spawn/3) to and [receive](https://hexdocs.pm/elixir/Kernel.SpecialForms.html#receive/1) to spawn a process that waits to receive a message. Use [Process.send_after/4](https://hexdocs.pm/elixir/Process.html#send_after/4) to send the spawned process a message after two seconds.
+Use [Process.spawn/3](https://hexdocs.pm/elixir/Process.html#spawn/3) and [receive](https://hexdocs.pm/elixir/Kernel.SpecialForms.html#receive/1) to spawn a process that waits to receive a message. Use [Process.send_after/4](https://hexdocs.pm/elixir/Process.html#send_after/4) to send the spawned process a message after two seconds.
 
 ```elixir
 

--- a/reading/genservers.livemd
+++ b/reading/genservers.livemd
@@ -340,7 +340,7 @@ GenServer.cast(pid, :slow_increment)
 
 ## Concurrency
 
-To have concurrent code, we simply need two GenServers. Notice both messages below finish at the same time because each is being processes concurrently.
+To have concurrent code, we simply need two GenServers. Notice both messages below finish at the same time because each is being processed concurrently.
 
 > If you have fewer CPU cores than processes, concurrent code does not run in **parallel**, so while code gains the benefits of task-switching typically giving the illusion of running in parallel, they will not actually process in parallel at the same time.
 

--- a/reading/supervisors.livemd
+++ b/reading/supervisors.livemd
@@ -286,7 +286,7 @@ flowchart TD
     class P2,P3,..,Pn restarted
 ```
 
-P2 crashed, the child processes after it in the start order are terminated, then P2 and the other terminated child processes are are restarted.
+P2 crashed, the child processes after it in the start order are terminated, then P2 and the other terminated child processes are restarted.
 
 ## Restart Strategy Examples
 


### PR DESCRIPTION
-Process drills: deleted superfluous & confusing 'to'
-GenServers reading: tense correction; changed '...being processes' to '...being processed'
-Supervisors reading: deleted duplicate word 'and'