### PR TITLE
Phoenix and Ecto section fixes

### DIFF
--- a/exercises/blog_posts.livemd
+++ b/exercises/blog_posts.livemd
@@ -230,7 +230,7 @@ iex> Repo.get!(Post, 2) |> Post.changeset(%{title: "updated title"}) |> Repo.upd
 <summary>Example Solution</summary>
 
 ```elixir
-iex> Blog.Repo.all(Blog.Posts.Post)
+iex> Repo.all(Post)
 ```
 
 </details>

--- a/exercises/traffic_light_server.livemd
+++ b/exercises/traffic_light_server.livemd
@@ -59,30 +59,30 @@ This is also a simple example of building a [Finite-state machine](https://en.wi
 * Handle an asynchronous `:transition` message to transition the current light.
 * Handle a synchronous `:current_light` message to retrieve the current light.
 * Create the `transition/1` and `current_light/1` messages as documented below.
-* Write a full suite of tests for the `TrafficLight` module.
+* Write a full suite of tests for the `TrafficLights` module.
 
 <!-- livebook:{"force_markdown":true} -->
 
 ```elixir
 {:ok, pid} = TrafficLights.Light.start_link([])
 
-:green = TrafficsLight.Light.current_light(pid)
-:ok = TrafficsLight.Light.transition(pid)
+:green = TrafficLights.Light.current_light(pid)
+:ok = TrafficLights.Light.transition(pid)
 
-:yellow = TrafficsLight.Light.current_light(pid)
-:ok = TrafficsLight.Light.transition(pid)
+:yellow = TrafficLights.Light.current_light(pid)
+:ok = TrafficLights.Light.transition(pid)
 
-:red = TrafficsLight.Light.current_light(pid)
-:ok = TrafficsLight.Light.transition(pid)
+:red = TrafficLights.Light.current_light(pid)
+:ok = TrafficLights.Light.transition(pid)
 
-:green = TrafficsLight.Light.current_light(pid)
+:green = TrafficLights.Light.current_light(pid)
 ```
 
 <details style="background-color: lightgreen; padding: 1rem; margin: 1rem 0;">
 <summary>Example Solution</summary>
 
 ```elixir
-defmodule TrafficLightServer do
+defmodule TrafficLights.Light do
   use GenServer
 
   def start_link(_opts) do
@@ -218,7 +218,7 @@ style R5 fill:lightcoral
 <summary>Example Solution</summary>
 
 ```elixir
-defmodule TrafficGridServer do
+defmodule TrafficLights.Grid do
   use GenServer
 
   def start_link(_opts) do
@@ -237,7 +237,7 @@ defmodule TrafficGridServer do
   def init(_opts) do
     light_pids =
       Enum.map(1..5, fn _ ->
-        {:ok, pid} = TrafficLightServer.start_link([])
+        {:ok, pid} = TrafficLights.Light.start_link([])
         pid
       end)
 
@@ -247,9 +247,9 @@ defmodule TrafficGridServer do
   @impl true
   def handle_call(:transition, _from, state) do
     light_pid = Enum.at(state.light_pids, state.transition_index)
-    TrafficLightServer.transition(light_pid)
+    TrafficLights.Light.transition(light_pid)
 
-    lights = Enum.map(state.light_pids, &TrafficLightServer.current_light/1)
+    lights = Enum.map(state.light_pids, &TrafficLights.Light.current_light/1)
     next_transition_index = rem(state.transition_index + 1, length(state.light_pids))
 
     {:reply, lights, %{state | transition_index: next_transition_index}}
@@ -257,7 +257,7 @@ defmodule TrafficGridServer do
 
   @impl true
   def handle_call(:current_lights, _from, state) do
-    lights = Enum.map(state.light_pids, &TrafficLightServer.current_light/1)
+    lights = Enum.map(state.light_pids, &TrafficLights.Light.current_light/1)
 
     {:reply, lights, state}
   end

--- a/reading/phoenix_and_ecto.livemd
+++ b/reading/phoenix_and_ecto.livemd
@@ -100,7 +100,7 @@ Phoenix contexts are a way of organizing related functionality in a Phoenix appl
 
 For example, we might have a `Blog` application with a `Posts` context that manages all operations for creating, editing, and deleting blog posts.
 
-Here's an example context module for a `Posts` context. We can see functions work with the `Post` context and the `Repo` module to retrieve, create, edit, and delete posts in the database.
+Here's an example context module for a `Posts` context. We can see functions work with the `Post` schema and the `Repo` module to retrieve, create, edit, and delete posts in the database.
 
 <!-- livebook:{"force_markdown":true} -->
 


### PR DESCRIPTION
Also added a fix to the Traffic Light Server exercise where module names had typos and were named inconsistently throughout.