### PR TITLE
fix typos in one to many reading

### DIFF
--- a/reading/apis.livemd
+++ b/reading/apis.livemd
@@ -316,7 +316,7 @@ APIs commonly return a JSON response. For example, here we make a request to a J
 
 ```elixir
 response =
-  Finch.build(:get, "https://v2.jokeapi.dev/joke/Any?safe-mode&format=json")
+  Finch.build(:get, "https://v2.jokeapi.dev/joke/Any?safe-mode&type=single&format=json")
   |> Finch.request!(MyApp.Finch)
 ```
 

--- a/reading/phoenix_authentication.livemd
+++ b/reading/phoenix_authentication.livemd
@@ -115,13 +115,13 @@ The generator creates a large number of files, here are a few you should familia
   * `user.ex`: The user schema.
   * `user_token.ex`: The user token schema.
   * `user_notifier.ex`: The mailer module for user emails such as account confirmation and resetting passwords.
-  * `user_auth.ex`: Useful functions for managing users on the web side of the application. For example, `require_authenticated_user/2` ensures a user is signed in before accessing some resource.
 * app web
   * `user_confirmation_controller.ex`: controller actions for confirming a user account
   * `user_registration_controller.ex`: controller actions for user sign up.
   * `user_reset_password_controller.ex`: controller actions for resetting a user's password.
   * `user_session_controller.ex`: controller actions for user log in and log out.
   * `user_settings_controller.ex`: controller actions for managing user settings.
+  * `user_auth.ex`: Useful functions for managing users on the web side of the application. For example, `require_authenticated_user/2` ensures a user is signed in before accessing some resource.
 * tests
   * `accounts_fixtures.ex`: fixture for creating users in tests.
   * the `register_and_log_in_user/1` and `log_in_user/2` function in the existing `conn_case.ex` file.

--- a/reading/phoenix_one_to_many_associations.livemd
+++ b/reading/phoenix_one_to_many_associations.livemd
@@ -41,13 +41,13 @@ Upon completing this lesson, a student should be able to answer the following qu
 
 ## Overview
 
-This is a companion reading for the [Blog: Search](../exercises/blog_search.livemd) exercise. This lesson is an overview of how to work with one-to-many associations in a Phoenix application.
+This is a companion reading for the [Blog: Comments](../exercises/blog_comments.livemd) exercise. This lesson is an overview of how to work with one-to-many associations in a Phoenix application.
 
 <!-- livebook:{"break_markdown":true} -->
 
 ### One To Many Associations
 
-In a one-to-many relationship, a single record in one table is associated with multiple records in another table. For example, a `Blog` might have many `Comments` associated with it.
+In a one-to-many relationship, a single record in one table is associated with multiple records in another table. For example, a `Post` might have many `Comments` associated with it.
 
 ```mermaid
 erDiagram


### PR DESCRIPTION
Edit: Also fixed the joke API call in the API reading, which sometimes would grab jokes of a format not compatible with the decoding example.