### PR TITLE
fix: Remove argumentError doctest

### DIFF
--- a/exercises/rpg_dialogue.livemd
+++ b/exercises/rpg_dialogue.livemd
@@ -90,13 +90,10 @@ defmodule Character do
 
   Defines a character struct, and functions for creating character dialogue.
 
-  iex> %Character{name: "Frodo"}
-  %Character{name: "Frodo", weapon: nil, class: nil}
+  iex> %Character{name: "Frodo", weapon: "Sting"}
+  %Character{name: "Frodo", weapon: "String", class: nil}
 
-  The :name key is required.
-
-  iex> %Character{name: "Frodo"}
-  ** (ArgumentError) the following keys must also be given when building struct Character: [:name]
+  The :name key is required. But cannot be tested by doctests
   """
   defstruct []
 


### PR DESCRIPTION
First, the test itself *should* work because the character has a `:name`, so I can't get that test to "pass". When changing it so it does throw an error, the whole liveview process throws an error:

![image](https://github.com/DockYard-Academy/curriculum/assets/2357736/7be518e3-e05e-41cf-91b2-038f2e2f4ec6)


Options I attempted:
1. I tried the original with no name passed to the struct
2. I tried using `assert_raise` with the third param, including the message but isn't required and made the test long (and still failed) 
3. I tried to use `assert_raise` as well but the argument error is still propagated to the livebook, and kills compilation.

```elixir
  iex> assert_raise ArgumentError, fn -> %Character{} end
  :ok
```
