### PR TITLE
Update Modules -> Multiple Function Clauses arity explanation

### DIFF
--- a/reading/modules.livemd
+++ b/reading/modules.livemd
@@ -482,7 +482,7 @@ MultipleFunctionClauses.my_function(1)
 
 Each function clause has a different **arity**. We can treat each function with a different arity as a completely separate function. In Elixir, we often refer to functions by their name and arity.
 
-So above we define `MultipleFunctionClauses.find_arity/1`, `MultipleFunctionClauses.find_arity/2`, and `MultipleFunctionClauses.find_arity/3` functions.
+So above we define `MultipleFunctionClauses.my_function/0`, `MultipleFunctionClauses.my_function/1`, and `MultipleFunctionClauses.my_function/2` functions.
 
 <!-- livebook:{"break_markdown":true} -->
 


### PR DESCRIPTION
Issue #1062 

Update explanation on Modules -> Multiple Function Clauses fixing the name of the defined multiple function created as example and its arities.

The goal is to keep the explanation related to the example.